### PR TITLE
Implement hiding code lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,28 @@ After it, run `mdbook build` or `serve`. That's it. All inline code and blocks w
 
 ## Settings
 
-Currently there are only two settings available: 
-- Whether to highlight inline blocks (default is yes):
+You can customize the preprocessor using the following settings:
 
-```toml
-[preprocessor.typst-highlight]
-disable_inline = true
-```
+- Whether to highlight inline blocks (default is to highlight them):
 
-- Whether to highlight and render blocks without language specified:
+    ```toml
+    [preprocessor.typst-highlight]
+    disable_inline = true
+    ```
 
-```toml
-[preprocessor.typst-highlight]
-typst_default = true
-```
+- Whether to highlight and render blocks without language specified (default is `false`):
+
+    ```toml
+    [preprocessor.typst-highlight]
+    typst_default = true
+    ```
+
+- What symbols to use for hiding code lines (default is none, read more in [the mdBook documentation](https://rust-lang.github.io/mdBook/format/mdbook.html?highlight=hide#hiding-code-lines)):
+
+    ```toml
+    [output.html.code.hidelines]
+    typst = "% "
+    ```
 
 # Rendering
 

--- a/example-book/book.toml
+++ b/example-book/book.toml
@@ -11,3 +11,6 @@ warn_not_specified = true
 
 # Uncomment the following line when developing
 # command = "cargo run --release"
+
+[output.html.code.hidelines]
+typst = "% "

--- a/example-book/src/chapter_1.md
+++ b/example-book/src/chapter_1.md
@@ -32,3 +32,37 @@ fn main() {
 }
 ```
 ````
+
+## Hidelines
+
+With the hidelines option configured as `"% "` prefix, the following code:
+
+```none
+% #let x = 10;
+The hidden $x$ value is #x.
+```
+
+will produce:
+
+```typ
+% #let x = 10;
+The hidden $x$ value is #x.
+```
+
+If you configure it as `"^^^"` prefix, then:
+
+````none
+```typ,hidelines=^^^
+Assume that `#add(x, y)` is defined.
+^^^#let add(x, y) = x + y;
+Then `#add(2, 3)` will be #add(2, 3).
+```
+````
+
+will result in:
+
+```typ,hidelines=^^^
+Assume that `#add(x, y)` is defined.
+^^^#let add(x, y) = x + y;
+Then `#add(2, 3)` will be #add(2, 3).
+```


### PR DESCRIPTION
Official mdBook documentation describes [how to hide specific code lines in block](https://rust-lang.github.io/mdBook/format/mdbook.html#hiding-code-lines) via following configuration:

```toml
[output.html.code.hidelines]
typst = "% "
```

or by code block specifically:

````
```typ,hidelines=^^^
^^^I will be hidden.
I will be visible.
```
````

As preprocessor modifies original code blocks, this won't work as is. This PR resolves that:

<details>
  <summary>Lines hidden by default</summary>

  <img width="1172" height="1049" alt="image" src="https://github.com/user-attachments/assets/56c1e5e8-7b79-4e85-9410-55872a0a0e13" />
</details>

<details>
  <summary>Visible hidden lines</summary>
  
  <img width="1171" height="1100" alt="image" src="https://github.com/user-attachments/assets/d867a70c-a88d-4987-b44e-86903815ae50" />
</details>

**CHANGES:**

1. Added `PreproccessSettings::hide_lines` field that is read from `output.html.code.hidelines` field in config.
2. Added reading `hidelines=...` option from code block, this option takes precedence over `PreproccessSettings::hide_lines`.
3. Markers are removed when highlighting and rendering, `<span class="boring">` is added when highlighting. This span automatically enables toggling lines visibility in mdBook.
4. Updated README.md and example book accordingly.