### PR TITLE
Update Typst's sublime syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,28 @@ After it, run `mdbook build` or `serve`. That's it. All inline code and blocks w
 
 ## Settings
 
-Currently there are only two settings available: 
-- Whether to highlight inline blocks (default is yes):
+You can customize the preprocessor using the following settings:
 
-```toml
-[preprocessor.typst-highlight]
-disable_inline = true
-```
+- Whether to highlight inline blocks (default is to highlight them):
 
-- Whether to highlight and render blocks without language specified:
+    ```toml
+    [preprocessor.typst-highlight]
+    disable_inline = true
+    ```
 
-```toml
-[preprocessor.typst-highlight]
-typst_default = true
-```
+- Whether to highlight and render blocks without language specified (default is `false`):
+
+    ```toml
+    [preprocessor.typst-highlight]
+    typst_default = true
+    ```
+
+- What symbols to use for hiding code lines (default is none, read more in [the mdBook documentation](https://rust-lang.github.io/mdBook/format/mdbook.html?highlight=hide#hiding-code-lines)):
+
+    ```toml
+    [output.html.code.hidelines]
+    typst = "% "
+    ```
 
 # Rendering
 

--- a/example-book/book.toml
+++ b/example-book/book.toml
@@ -11,3 +11,6 @@ warn_not_specified = true
 
 # Uncomment the following line when developing
 # command = "cargo run --release"
+
+[output.html.code.hidelines]
+typst = "% "

--- a/example-book/src/chapter_1.md
+++ b/example-book/src/chapter_1.md
@@ -53,16 +53,16 @@ If you configure it as `"^^^"` prefix, then:
 
 ````none
 ```typ,hidelines=^^^
-Assume that `#add(x, y)` is defined.
+Assume that ```typ #add(x, y)``` is defined.
 ^^^#let add(x, y) = x + y;
-Then `#add(2, 3)` will be #add(2, 3).
+Then ```typ #add(2, 3)``` will be #add(2, 3).
 ```
 ````
 
 will result in:
 
 ```typ,hidelines=^^^
-Assume that `#add(x, y)` is defined.
+Assume that ```typ #add(x, y)``` is defined.
 ^^^#let add(x, y) = x + y;
-Then `#add(2, 3)` will be #add(2, 3).
+Then ```typ #add(2, 3)``` will be #add(2, 3).
 ```

--- a/example-book/src/chapter_1.md
+++ b/example-book/src/chapter_1.md
@@ -32,3 +32,37 @@ fn main() {
 }
 ```
 ````
+
+## Hidelines
+
+With the hidelines option configured as `"% "` prefix, the following code:
+
+```none
+% #let x = 10;
+The hidden $x$ value is #x.
+```
+
+will produce:
+
+```typ
+% #let x = 10;
+The hidden $x$ value is #x.
+```
+
+If you configure it as `"^^^"` prefix, then:
+
+````none
+```typ,hidelines=^^^
+Assume that `#add(x, y)` is defined.
+^^^#let add(x, y) = x + y;
+Then `#add(2, 3)` will be #add(2, 3).
+```
+````
+
+will result in:
+
+```typ,hidelines=^^^
+Assume that `#add(x, y)` is defined.
+^^^#let add(x, y) = x + y;
+Then `#add(2, 3)` will be #add(2, 3).
+```

--- a/res/Typst.sublime-syntax
+++ b/res/Typst.sublime-syntax
@@ -2,6 +2,7 @@
 ---
 # - https://www.sublimetext.com/docs/syntax.html
 # - https://typst.app/docs/reference/syntax
+# - original source code: https://github.com/hyrious/typst-syntax-highlight/blob/main/Typst.sublime-syntax
 
 file_extensions:
   - typ
@@ -15,16 +16,18 @@ scope: text.typst
 version: 2
 
 variables:
+  break: (?=\b|_)
   html_entity: '&([a-zA-Z0-9]+|#\d+|#[Xx]\h+);'
   no_escape_behind: '(?<![^\\]\\)(?<![\\]{3})'
   markup_symbol_shorthands: (\.\.\.|---?|-\?|~)
-  math_symbol_shorthands: (->>?|-->|::?=|!=|\[\||<==?>|<--?>|<--?|<-<|<<-|<<<?|<==?|<~~?|>->|>>>?|==?>|=:|>=|\|[-=]>|\|\]|\|\||~~?>|')
-  greeks: (alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|iota|gamma|kappa|lambda|mu|nu|xi|pi|varpi|rho|varrho|sigma|varsigma|tau|upsilon|phi|varphi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega)
+  math_symbol_shorthands: (->>?|-->|::?=|!=|\[\||<==?>|<--?>|<--?|<-<|<<-|<<<?|<==?|<~~?|>->|>>>?|==?>|=:|>=|\*|\|[-=]>|\|\]|\|\||~~?>|')
   non_raw_ident: '[[:alpha:]][-_[:alnum:]]*|_[-_[:alnum:]]+'
   identifier: '(?:{{non_raw_ident}})'
-  operators: ([-+*/]=?|=>|==?|[<>]=?|\bin\b|\bnot\s+in\b|\bnot\b|\band\b|\bor\b)
-  prefixes: (?:(?:include|import|set|let|if|for|while|show)\b)
-  end_of_emph: '[a-zA-Z0-9]'
+  operators: ([+*/]=?|!=|\B-=?|=>|==?|[<>]=?|\bnot\s+in\b)
+  prefixes: (?:(?:include|import|set|let|if|for|while|show|context|regex)\b)
+  word_without_underscore: '[a-zA-Z0-9]'
+  no_space_nor_punct: (?![\s*\p{P}])
+  no_space_but_punct: (?=[[^\s*]&&\p{P}])
 
 contexts:
   # The prototype context is prepended to all contexts but those setting
@@ -34,6 +37,10 @@ contexts:
 
   main:
     - include: markups
+
+  else-pop:
+    - match: ''
+      pop: true
 
   # https://typst.app/docs/reference/syntax/#markup
   markups:
@@ -72,6 +79,7 @@ contexts:
   block-comment-body:
     - meta_include_prototype: false
     - meta_scope: comment.block.typst
+    - include: block-comments
     - include: block-comment-end
 
   block-comment-end:
@@ -91,7 +99,7 @@ contexts:
 
   # https://typst.app/docs/reference/meta/heading
   headings:
-    - match: ^\s*(=+)\s*
+    - match: ^\s*(=+)\s+
       captures:
         1: punctuation.definition.heading.begin.typst
       push: heading-content
@@ -105,12 +113,12 @@ contexts:
     - include: inlines
 
   list-blocks:
-    # https://typst.app/docs/reference/layout/list
+    # https://typst.app/docs/reference/model/list
     - match: ^\s*(-)\s
       captures:
         1: markup.list.unnumbered.bullet.typst punctuation.definition.list_item.typst
       push: unordered-list-block
-    # https://typst.app/docs/reference/layout/enum
+    # https://typst.app/docs/reference/model/enum
     - match: ^\s*(\+)\s
       captures:
         1: markup.list.numbered.bullet.typst punctuation.definition.list_item.typst
@@ -132,6 +140,8 @@ contexts:
 
   list-block-end:
     - match: ^(?=\S)
+      pop: true
+    - match: ^(?=\s*\])
       pop: true
 
   list-block-content:
@@ -156,10 +166,9 @@ contexts:
 
   fenced-code-block-content:
     - meta_scope: meta.code-fence.typst
-    - match: $
-      pop: true
     - include: fenced-syntaxes
     - include: fenced-raw
+    - include: else-pop
 
   fenced-syntaxes:
     - include: fenced-actionscript
@@ -203,6 +212,7 @@ contexts:
     - include: fenced-sql
     - include: fenced-tsx
     - include: fenced-typescript
+    - include: fenced-typst
     - include: fenced-xml
     - include: fenced-yaml
 
@@ -657,6 +667,26 @@ contexts:
       escape_captures:
         1: punctuation.definition.raw.code-fence.end.typst
 
+  fenced-typst:
+    - match: (`{3,})((?i:typst|typ))($\n?|\b)
+      captures:
+        1: punctuation.definition.raw.code-fence.begin.typst
+        2: constant.other.language-name.typst
+      embed: scope:text.typst
+      embed_scope: markup.raw.block.typst.typst text.typst
+      escape: '(?:^[ \t]*)?(\1)\s*'
+      escape_captures:
+        1: punctuation.definition.raw.code-fence.end.typst
+    - match: (`{3,})((?i:typc))($\n?|\b)
+      captures:
+        1: punctuation.definition.raw.code-fence.begin.typst
+        2: constant.other.language-name.typst
+      embed: scope:text.typst#script-common
+      embed_scope: markup.raw.block.typst.typst text.typst
+      escape: '(?:^[ \t]*)?(\1)\s*'
+      escape_captures:
+        1: punctuation.definition.raw.code-fence.end.typst
+
   fenced-xml:
     - match: (`{3,})((?i:atom|plist|svg|xjb|xml|xsd|xsl))($\n?|\b)
       captures:
@@ -688,20 +718,29 @@ contexts:
       push: fenced-raw-content
 
   fenced-raw-content:
+    - meta_include_prototype: false
     - meta_content_scope: markup.raw.block.typst
     - match: '(?:^[ \t]*)?(\1)\s*($\n?)?'
       captures:
         1: punctuation.definition.raw.code-fence.end.typst
       pop: true
 
-  # https://typst.app/docs/reference/layout/terms
+  # https://typst.app/docs/reference/model/terms
   terms:
-    - match: \s*(/)\s*(\w+)(:)
-      scope: markup.terms.typst
+    - match: ^\s*(/)[ ]
       captures:
         1: punctuation.definition.term.typst
-        2: entity.name.enum.typst
-        3: punctuation.separator.key-value.typst
+      push: term-body
+
+  term-body:
+    - meta_scope: markup.terms.typst
+    - meta_content_scope: entity.name.enum.typst
+    - match: ':'
+      scope: punctuation.separator.key-value.typst
+      pop: true
+    - match: ^(?=\S)
+      pop: true
+    - include: markups
 
 ###[ Inline ]#################################################################
 
@@ -729,69 +768,34 @@ contexts:
     - include: bold
     - include: italic
 
-  # https://typst.app/docs/reference/text/strong
+  # https://typst.app/docs/reference/model/strong
   bold:
-    - match: (?<!\S)\*
+    - match: (?<!{{word_without_underscore}})\*{{no_space_nor_punct}}|\B\*{{no_space_but_punct}}|\b\*(?!{{word_without_underscore}})
       scope: punctuation.definition.bold.begin.typst
       push: bold-content
 
   bold-content:
     - meta_scope: markup.bold.typst
-    - match: \*(?!{{end_of_emph}})
+    - match: \*(?!{{word_without_underscore}})
       scope: punctuation.definition.bold.end.typst
       pop: true
     - include: inlines
 
-  # https://typst.app/docs/reference/text/emph
+  # https://typst.app/docs/reference/model/emph
   italic:
-    - match: (?<!\S)_
+    - match: \b_(?=\S)(?!_)
       scope: punctuation.definition.italic.begin.typst
       push: italic-content
 
   italic-content:
     - meta_scope: markup.italic.typst
-    - match: _(?!{{end_of_emph}})
+    - match: _\b
       scope: punctuation.definition.italic.end.typst
       pop: true
     - include: inlines
 
-  bold-italic:
-    - match: (?<!\S)(\*)(_)
-      captures:
-        1: punctuation.definition.bold.begin.typst
-        2: punctuation.definition.italic.begin.typst
-      push:
-        - bold-content
-        - bold-italic-content
-
-  bold-italic-content:
-    - meta_scope: markup.italic.typst
-    - match: (_)(\*)(?!{{end_of_emph}})
-      captures:
-        1: punctuation.definition.italic.end.typst
-        2: punctuation.definition.bold.end.typst
-      pop: 2
-    - include: italic-content
-
-  italic-bold:
-    - match: (?<!\S)(_)(\*)
-      captures:
-        1: punctuation.definition.italic.begin.typst
-        2: punctuation.definition.bold.begin.typst
-      push:
-        - italic-content
-        - italic-bold-content
-
-  italic-bold-content:
-    - meta_scope: markup.bold.typst
-    - match: (\*)(_)(?!{{end_of_emph}})
-      captures:
-        1: punctuation.definition.bold.end.typst
-        2: punctuation.definition.italic.end.typst
-      pop: 2
-    - include: bold-content
-
   literals:
+    - include: fenced-code-blocks
     - include: code-spans
     - include: escaped-char
 
@@ -802,6 +806,7 @@ contexts:
       push: code-span-body
 
   code-span-body:
+    - meta_include_prototype: false
     - meta_scope: markup.raw.inline.typst
     - match: \1(?!`)
       scope: punctuation.definition.raw.end.typst
@@ -844,29 +849,30 @@ contexts:
       captures:
         1: punctuation.definition.escape.typst
 
-  # https://typst.app/docs/reference/construct/label
+  # https://typst.app/docs/reference/foundations/label
   labels:
-    - match: '(<)([-_\w]+)(>)'
+    - match: '(<)([-_:\w]+)(>)'
       scope: storage.modifier.label.typst
       captures:
         1: punctuation.definition.label.begin.typst
         2: entity.name.label.typst
         3: punctuation.definition.label.end.typst
 
-  # https://typst.app/docs/reference/meta/ref
+  # https://typst.app/docs/reference/model/ref
   refs:
-    - match: '(@)[-_\w]+'
+    - match: '(@)[-_:\w]+'
       scope: constant.other.reference.typst
       captures:
         1: punctuation.definition.reference.typst
       push: maybe-ref-content
+    - match: '@'
+      scope: punctuation.definition.reference.typst
 
   maybe-ref-content:
     - match: '\['
       scope: punctuation.definition.generic.begin.typst
       push: ref-content
-    - match: ''
-      pop: true
+    - include: else-pop
 
   ref-content:
     - match: '\]'
@@ -876,17 +882,25 @@ contexts:
 
   # https://typst.app/docs/reference/symbols/sym
   symbols:
+    - match: (#)(sym)(\.)
+      captures:
+        1: punctuation.definition.expression.typst
+        2: support.module.sym.typst
+        3: punctuation.accessor.dot.typst
+      push:
+        - include: named-general-symbols
+        - include: else-pop
     - match: (#)(?!{{prefixes}})({{identifier}}(?:(\.){{identifier}})*)(?=[\[\(])
       scope: support.other.typst variable.function.typst
       captures:
         1: punctuation.definition.expression.typst
-        3: punctuation.accessor.typst
+        3: punctuation.accessor.dot.typst
       push: maybe-script-function-content
     - match: (#)(?!{{prefixes}})({{identifier}}(?:(\.){{identifier}})*)
       scope: meta.expression.typst constant.other.symbol.typst
       captures:
         1: punctuation.definition.variable.typst
-        3: punctuation.accessor.typst
+        3: punctuation.accessor.dot.typst
     - match: '{{markup_symbol_shorthands}}'
       scope: constant.other.typst
 
@@ -906,74 +920,138 @@ contexts:
     - include: math-common
 
   math-common:
-    - include: greeks
-    - include: math-functions
     - include: math-brackets
     - include: math-numerics
+    - include: math-accent-functions
     - include: math-symbols
     - include: math-operators
+    - include: math-attachments
+    - include: math-punctuations
+    - include: math-spacings
+    - include: math-functions
+    - include: math-variables
     - include: symbols
     - include: strings
     - include: scripts
 
-  greeks:
-    - match: '\b{{greeks}}\b'
+  math-accent-functions:
+    - match: (grave|hat|tilde|macron|dash|breve|diaer|circle|caron)(?=\()
       captures:
-        1: support.constant.greek.math.typst
+        1: support.function.math.typst
+        2: punctuation.section.group.begin.typst
+      push: maybe-math-function-params
+    - match: (dot)(?:(\.)(double|triple|quad))?(?=\()
+      captures:
+        1: support.function.math.typst
+        2: punctuation.accessor.dot.typst
+        3: support.function.math.modifier.typst
+        4: punctuation.section.group.begin.typst
+      push: maybe-math-function-params
+    - match: (acute)(?:(\.)(double))?(?=\()
+      captures:
+        1: support.function.math.typst
+        2: punctuation.accessor.dot.typst
+        3: support.function.math.modifier.typst
+        4: punctuation.section.group.begin.typst
+      push: maybe-math-function-params
+    - match: (arrow)(?:(\.)(l)(?:(\.)(r))?)?(?=\()
+      captures:
+        1: support.function.math.typst
+        2: punctuation.accessor.dot.typst
+        3: support.function.math.modifier.typst
+        4: punctuation.accessor.dot.typst
+        5: support.function.math.modifier.typst
+        6: punctuation.section.group.begin.typst
+      push: maybe-math-function-params
+    - match: (harpoon)(?:(\.)(lt))?(?=\()
+      captures:
+        1: support.function.math.typst
+        2: punctuation.accessor.dot.typst
+        3: support.function.math.modifier.typst
+        4: punctuation.section.group.begin.typst
+      push: maybe-math-function-params
 
   math-functions:
-    - match: '(\.)?([[:alpha:]]+)(\()'
+    - match: (?:dif|Dif){{break}}
+      scope: support.constant.math.typst
+    - match: (?:arccos|arcsin|arctan|arg|cos|cosh|cot|coth|csc|csch|ctg|deg|det|dim|exp|gcd|lcm|hom|id|im|inf|ker|lg|lim|liminf|limsup|ln|log|max|min|mod|Pr|sec|sech|sin|sinc|sinh|sup|tan|tanh|tg|tr){{break}}
+      scope: support.constant.math.operator.typst
+    - match: (?:abs|attach|bb|binom|bold|cal|cancel|cases|ceil|class|display|floor|frac|frak|inline|italic|limits|lr|mat|mid|mono|norm|op|overbrace|overbracket|overline|overparen|overshell|primes|root|round|sans|scripts?|serif|sqrt|sscript|stretch|underbrace|underbracket|underline|underparen|undershell|upright|vec)\b
+      scope: support.function.math.typst
+      push: maybe-math-function-params
+    - match: '(\.)?([[:alpha:]][[:alnum:]]+)'
       captures:
-        1: punctuation.accessor.typst
-        2: support.function.math.typst
-        3: punctuation.section.group.begin.typst
-      push: math-function-params
-    - match: '(\.)?([[:alpha:]]{2,})'
-      captures:
-        1: punctuation.accessor.typst
-        2: support.function.math.typst
+        1: punctuation.accessor.dot.typst
+        2: variable.function.math.typst
+      push: maybe-math-function-params
+
+  math-variables:
     - match: '(\.)?([[:alpha:]])'
       captures:
-        1: punctuation.accessor.typst
+        1: punctuation.accessor.dot.typst
         2: variable.other.math.typst
 
-  math-brackets:
-    - match: '\('
-      scope: constant.character.parenthesis.typst
-      push: math-bracket-content
+  maybe-math-group:
+    - match: \(
+      scope: punctuation.section.group.begin.typst
+      set: math-group-content
+    - include: else-pop
 
-  math-bracket-content:
+  math-group-content:
     - match: (?=\$)
       pop: true
-    - match: (\))
-      captures:
-        1: constant.character.parenthesis.typst
+    - match: \)
+      scope: punctuation.section.group.end.typst
       pop: true
     - include: math-common
-    - include: script-symbols
+
+  maybe-math-function-params:
+    - match: \(
+      scope: punctuation.section.group.begin.typst
+      set: math-function-params
+    - include: else-pop
 
   math-function-params:
+    - meta_scope: meta.function-call.arguments.typst
     - match: (?=\$)
       pop: true
-    - match: (\))
-      captures:
-        1: punctuation.section.group.end.typst
+    - match: \)
+      scope: punctuation.section.group.end.typst
       pop: true
+    - match: '({{identifier}})\s*(:)'
+      captures:
+        1: variable.parameter.typst
+        2: punctuation.separator.key-value.typst
     - include: math-common
     - include: script-symbols
 
+  math-brackets:
+    - match: \(
+      scope: constant.character.parenthesis.typst
+      push: math-brackets-content
+    - match: \)
+      scope: constant.character.parenthesis.typst
+
+  math-brackets-content:
+    - match: (?=\$)
+      pop: true
+    - match: \)
+      scope: constant.character.parenthesis.typst
+      pop: true
+    - include: math-common
+
   math-numerics:
-    - match: \b(0x)(\h+)
+    - match: (0x)(\h+)
       scope: meta.number.integer.hexadecimal.typst
       captures:
         1: constant.numeric.base.typst
         2: constant.numeric.value.typst
-    - match: \b(0o)([0-7]+)
+    - match: (0o)([0-7]+)
       scope: meta.number.integer.octal.typst
       captures:
         1: constant.numeric.base.typst
         2: constant.numeric.value.typst
-    - match: \b(0b)([01]+)
+    - match: (0b)([01]+)
       scope: meta.number.integer.binary.typst
       captures:
         1: constant.numeric.base.typst
@@ -984,7 +1062,7 @@ contexts:
         1: constant.numeric.value.typst
         2: punctuation.separator.decimal.typst
         3: constant.numeric.suffix.typst
-    - match: \b(\d+)(%|(?:pt|mm|cm|in|em|deg|rad|fr)\b)?
+    - match: (\d+)(%|(?:pt|mm|cm|in|em|deg|rad|fr)\b)?
       scope: meta.number.integer.decimal.typst
       captures:
         1: constant.numeric.value.typst
@@ -993,22 +1071,42 @@ contexts:
   math-symbols:
     - match: '{{math_symbol_shorthands}}'
       scope: constant.other.typst
-    - match: '&'
-      scope: constant.character.ampersand.typst
+    - match: \+|\-|=|<|>
+      scope: constant.other.typst
     - match: '~'
       scope: constant.character.space.typst
     - include: escaped-char
     - include: hard-line-breaks
+    - include: named-general-symbols
 
   escaped-char:
-    - match: '(\\).'
+    - match: '(\\)(u)(\h{4}|\{\h+\})'
+      scope: constant.character.escape.typst
+      captures:
+        1: punctuation.definition.backslash.typst
+    - match: '(\\)[\S\s]'
       scope: constant.character.escape.typst
       captures:
         1: punctuation.definition.backslash.typst
 
   math-operators:
-    - match: \+|\-|=|-|\*|/|\^|_|<|>
+    - match: '[&/]'
       scope: keyword.operator.math.typst
+
+  math-attachments:
+    - match: \^|_
+      scope: keyword.operator.math.typst
+      push: maybe-math-group
+
+  math-punctuations:
+    - match: \,
+      scope: punctuation.separator.comma.typst
+    - match: ':'
+      scope: punctuation.separator.colon.typst
+
+  math-spacings:
+    - match: \b(?:thin|med|thick|quad|wide)\b
+      scope: support.constant.math.typst
 
 ###[ Scripting ]##############################################################
 
@@ -1024,15 +1122,15 @@ contexts:
 
   script-statement:
     - meta_scope: meta.expression.typst
-    - match: $\n?
-      #      ^ TODO: this is incorrect, but matching a random "expression" is also hard..
+    - match: (?=[\]])|$\n?
+      #      ^ matching a random "expression" is hard, stop early when seeing newline or ]
       pop: true
     - include: script-common
 
   script-expression:
     - meta_scope: meta.expression.typst
-    - match: (?=[\s\]\$])
-      #      ^ stop scripting when seeing space or ] or $, maybe wrong
+    - match: (?=[\s\]\$\:])
+      #      ^ stop scripting when seeing space or ] or $ or :, maybe wrong
       pop: true
     - include: script-common
 
@@ -1040,6 +1138,7 @@ contexts:
     - include: script-blocks
     - include: content-blocks
     - include: maths
+    - include: regexes
     - include: escaped-char
     - include: labels
     #          ^ not knowing the boundary of one-liners..
@@ -1078,6 +1177,8 @@ contexts:
 
   statements:
     - include: strings
+    - include: fenced-code-blocks
+    - include: code-spans
     - include: script-functions
     - include: keywords
     - include: script-operators
@@ -1086,20 +1187,25 @@ contexts:
     - include: hard-line-breaks
 
   keywords:
-    - match: '\b(include|import)\b'
+    - match: '(?<!-)\b(include|import)\b(?!-)'
       scope: keyword.import.typst
-    - match: '\b(let|set|show)\b'
+    - match: '(?<!-)\b(as)\b(?!-)'
+      scope: keyword.control.import.as.typst
+    - match: '(?<!-)\b(let|set|show|context)\b(?!-)'
       scope: keyword.declaration.typst
-    - match: '\b(if|else|for|in|while|break)\b'
+    - match: '(?<!-)\b(if|else|for|while|break|continue|return)\b(?!-)'
       scope: keyword.control.typst
-    - match: '\b(none)\b'
+    - match: '(?<!-)\b(none)\b(?!-)'
       scope: constant.language.null.typst
-    - match: '\b(auto)\b'
+    - match: '(?<!-)\b(auto)\b(?!-)'
       scope: constant.language.auto.typst
-    - match: '\b(true|false)\b'
+    - match: '(?<!-)\b(true|false)\b(?!-)'
       scope: constant.language.boolean.typst
 
   script-operators:
+    - match: '(?<!-)\b(in|and|not|or)\b(?!-)'
+      captures:
+        1: keyword.operator.typst
     - match: '{{operators}}'
       captures:
         1: keyword.operator.typst
@@ -1108,7 +1214,7 @@ contexts:
     - match: ':'
       scope: punctuation.separator.key-value.typst
     - match: ','
-      scope: punctuation.separator.typst
+      scope: punctuation.separator.comma.typst
     - match: ';'
       scope: punctuation.terminator.typst
     - match: '\.\.'
@@ -1124,49 +1230,996 @@ contexts:
   string-content:
     - meta_include_prototype: false
     - meta_scope: string.quoted.double.typst
+    - include: escaped-char
     - match: '"'
       scope: punctuation.definition.string.end.typst
       pop: true
 
   maybe-script-function-content:
     - meta_scope: meta.expression.typst
-    - match: (?:(\.)({{identifier}}))?(\()
+    - match: (?:(\.)({{identifier}}))?(?=\()
       captures:
-        1: punctuation.accessor.typst
+        1: punctuation.accessor.dot.typst
         2: support.function.typst
         3: punctuation.section.group.begin.typst
-      push: script-function-params
+      push: maybe-script-function-params
     - match: (?:(\.)({{identifier}}))?(\[)
       captures:
-        1: punctuation.accessor.typst
+        1: punctuation.accessor.dot.typst
         2: support.function.typst
         3: punctuation.section.group.begin.typst
       push: content-block-content
-    - match: ''
+    - include: else-pop
+
+  # https://typst.app/docs/reference/foundations/regex
+  # https://docs.rs/regex/latest/regex/#syntax
+  # The JavaScript's regex definition is quite close to Typst's
+  regexes:
+    - match: '\b(regex)(\()(")'
+      captures:
+        1: support.function.typst
+        2: punctuation.section.group.begin.typst
+        3: punctuation.definition.string.begin.typst
+      push:
+        - script-function-params
+        - regex-string-body
+    - match: '\b(regex)(\()(`)'
+      captures:
+        1: support.function.typst
+        2: punctuation.section.group.begin.typst
+        3: markup.raw.inline.typst punctuation.definition.raw.begin.typst
+      push:
+        - script-function-params
+        - regex-raw-body
+
+  regex-string-body:
+    - meta_include_prototype: false
+    - meta_content_scope: string.regexp.typst
+    - match: '(?<!\\)"'
+      scope: punctuation.definition.string.end.typst
       pop: true
+    - include: scope:source.regexp.js
+
+  regex-raw-body:
+    - meta_content_scope: markup.raw.inline.typst string.regexp.typst
+    - match: \3(?!`)
+      scope: markup.raw.inline.typst punctuation.definition.raw.end.typst
+      pop: true
+    - match: (`+)
+    - include: scope:source.regexp.js
 
   script-functions:
-    - match: '(\.)?({{identifier}})(\()'
+    - match: '(\.)?({{identifier}})(?=\()'
       captures:
-        1: punctuation.accessor.typst
+        1: punctuation.accessor.dot.typst
         2: support.function.typst
         3: punctuation.section.group.begin.typst
-      push: script-function-params
+      push: maybe-script-function-params
     - match: '(\.)?({{identifier}})(\[)'
       captures:
-        1: punctuation.accessor.typst
+        1: punctuation.accessor.dot.typst
         2: support.function.typst
         3: punctuation.section.group.begin.typst
       push: content-block-content
+
+  maybe-script-function-params:
+    - match: \(
+      scope: punctuation.section.group.begin.typst
+      set: script-function-params
+    - include: else-pop
 
   script-function-params:
     - meta_scope: meta.function-call.arguments.typst
-    - match: (\))
-      captures:
-        1: punctuation.section.group.end.typst
+    - match: \)
+      scope: punctuation.section.group.end.typst
       pop: true
     - match: '({{identifier}})\s*(:)'
       captures:
         1: variable.parameter.typst
         2: punctuation.separator.parameter.typst
     - include: script-common
+
+###[ Named General Symbols ]##################################################
+
+  consume-and-pop:  # consume any number of alphabetic characters and pop
+    - match: '[[:alpha:]]*'
+      pop: true
+
+  named-general-symbols:
+    - match: (Theta|beta|kappa|phi|pi|rho|theta|sigma)(\.)
+      captures:
+        1: support.constant.sym.greek.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: alt{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (xor)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: big{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (product)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: co{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (acute|multimap)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: double{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (perp)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: circle{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (lat|smt)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: eq{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (crossmark)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: heavy{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (sum)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: integral{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (Omega|amp|interrobang|iota)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: inv{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (mapsto)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: long{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (asymp|equiv|exists|forces)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: not{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (compose|convolve)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: o{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (peso)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: philippine{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (planck)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: reduce{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (pilcrow)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: rev{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (copyright)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: sound{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (parallelogram)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: stroked{{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (arrowhead|natural)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: '[bt]{{break}}'
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (bag|ceil|floor|floral|mustache)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: '[lr]{{break}}'
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (dotless)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: '[ij]{{break}}'
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (hexa|hourglass|penta)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:filled|stroked){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (trademark)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:registered|service){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (approx)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:eq|not){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (backslash)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:circle|not){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (cc)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:by|nc|nd|public|sa|zero){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (checkmark)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:heavy|light){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (and|or)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:big|curly|dot|double){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (hyph)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:minus|nobreak|point|soft){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (infinity)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:bar|incomplete|tie){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (interleave)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:big|struck){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (minus)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:circle|dot|o|plus|square|tilde|triangle){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (quest)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:double|excl|inv){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (slash)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:big|double|o|triple){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (star)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:filled|op|stroked){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (ast)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:basic|circle|double|low|o|op|small|square|triple){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (dagger)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:double|inv|l|r|triple){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (die)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:one|two|three|four|five|six){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (excl)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:double|inv|quest){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (flat|sharp)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (?:b|double|quarter|t){{break}}
+          scope: support.constant.sym.modifier.typst
+          pop: true
+        - include: consume-and-pop
+    - match: (angle)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (acute|arc|azimuth|curly|dot|double|l|oblique|obtuse|r|rev|right|s|spatial|spheric|sq|top)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (arrow)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (b|bar|bl|br|ccw|curve|cw|dashed|dotted|double|dstruck|filled|half|hook|l|long|loop|not|open|quad|r|squiggly|stop|stroked|struck|t|tail|tilde|tl|tr|triple|turn|twohead|wave|zigzag)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (arrows)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (bb|bt|ll|lll|lr|rl|rr|rrr|stop|tb|tt)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (ballot)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (check|cross|heavy)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (bar)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (broken|circle|double|h|triple|v)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (brace)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (b|double|l|r|t)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (bracket)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (b|l|r|t|tick)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (bullet)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (hole|hyph|l|o|op|r|stroked|tri)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (chevron)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (closed|l|r)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (circle)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (big|dotted|filled|nested|small|stroked|tiny)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (colon)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (currency|double|eq|op|tri)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (comma|semi)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (inv|rev)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (corner)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (b|l|r|t)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (dash)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (circle|colon|double|em|en|fig|three|two|wave)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (diamond)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (dot|filled|medium|small|stroked)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (div)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (circle|o|slanted)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (divides)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (not|rev|struck)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (dot)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (basic|big|c|circle|double|o|op|quad|square|triple)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (dots)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (c|down|h|up|v)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (ellipse|rect)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (filled|h|stroked|v)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (emptyset|nothing)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (arrow|bar|circle|l|r|rev)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (epsilon)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (alt|rev)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (eq)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (circle|colon|def|delta|dots|down|equi|est|gt|lt|m|not|prec|quad|quest|small|star|succ|triple|up)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (errorbar)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (circle|diamond|filled|square|stroked)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (fence)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (dotted|double|l|r)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (gender)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (double|female|intersex|male|neuter|r|stroke|t|trans)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (gt)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (approx|circle|dot|double|eq|equiv|lt|napprox|neq|nequiv|nested|not|ntilde|slant|small|tilde|tri|triple)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (harpoon)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (bar|bl|blbr|bltr|br|lb|lbrb|lt|ltlb|ltrb|ltrt|rb|rblb|rt|rtlb|rtlt|rtrb|stop|tl|tlbr|tltr|tr)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (in)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (not|rev|small)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (integral)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (arrow|ccw|cw|cont|dash|double|hook|inter|quad|slash|square|surf|times|triple|union|vol)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (inter)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (and|big|dot|double|sq)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (join)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (l|r)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (lozenge)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (filled|medium|small|stroked)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (lt)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (approx|circle|dot|double|eq|equiv|gt|napprox|neq|nequiv|nested|not|ntilde|slant|small|tilde|tri|triple)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (note)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (alt|beamed|down|eighth|grace|half|quarter|sixteenth|slash|up|whole)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (parallel)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (circle|eq|equiv|not|slanted|struck|tilde)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (paren)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (b|closed|double|flat|l|r|t)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (plus)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (arrow|big|circle|dot|double|l|minus|o|r|small|square|triangle|triple)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (power)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (off|on|sleep)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (prec|succ)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (approx|curly|double|eq|equiv|napprox|neq|nequiv|not|ntilde|tilde)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (prime)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (double|quad|rev|triple)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (quote)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (angle|double|high|l|low|r|single)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (rest)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (eighth|half|measure|multiple|quarter|sixteenth|whole)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (rupee)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (generic|indian|tamil|wancho)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (shell)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (b|double|filled|l|r|t)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (space)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (en|fig|hair|med|narrow|nobreak|punct|quad|quarter|sixth|thin|third)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (square)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (big|dotted|filled|medium|rounded|small|stroked|tiny)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (subset|supset)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (dot|double|eq|neq|not|sq)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (suit)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (club|diamond|filled|heart|spade|stroked)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (tack)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (b|big|double|l|long|not|r|short|t)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (tilde)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (basic|dot|eq|equiv|nequiv|not|op|rev|triple)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (times)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (big|circle|div|hat|l|o|r|square|three|triangle)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (triangle)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (b|bl|br|dot|filled|l|nested|r|rounded|small|stroked|t|tl|tr)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (union)(\.)
+      captures:
+        1: support.constant.sym.typst
+        2: punctuation.accessor.dot.typst
+      push:
+        - match: (arrow|big|dot|double|minus|or|plus|sq)(?:(\.)|{{break}})
+          captures:
+            1: support.constant.sym.modifier.typst
+            2: punctuation.accessor.dot.typst
+        - include: consume-and-pop
+    - match: (?:AA|BB|CC|DD|EE|FF|GG|HH|II|JJ|KK|LL|MM|NN|OO|PP|QQ|RR|SS|TT|UU|VV|WW|XX|YY|ZZ){{break}}
+      scope: support.constant.sym.typst
+    - match: (?:Alpha|Beta|Chi|Delta|Digamma|Epsilon|Eta|Gamma|Iota|Kai|Kappa|Lambda|Mu|Nu|Omega|Omicron|Phi|Pi|Psi|Rho|Sigma|Tau|Theta|Upsilon|Xi|Zeta|alpha|beta|chi|delta|digamma|epsilon|eta|gamma|iota|kappa|lambda|mu|nu|omega|omicron|phi|pi|psi|rho|sigma|tau|theta|upsilon|xi|zeta){{break}}
+      scope: support.constant.sym.greek.typst
+    - match: (?:Im|Re|Sha|acute|afghani|aleph|amp|and|angle|angstrom|angzarr|approx|arrow|arrowhead|arrows|ast|asymp|at|backslash|bag|baht|ballot|bar|because|beth|bitcoin|bot|brace|bracket|breve|bullet|caret|caron|cc|cedi|ceil|cent|checkmark|chevron|circle|co|colon|comma|complement|compose|convolve|copyleft|copyright|corner|crossmark|currency|dagger|daleth|dash|degree|diaer|diameter|diamond|die|div|divides|dollar|dong|dorome|dots?|dotless|dram|earth|ell|ellipse|emptyset|eq|equiv|errorbar|euro|excl|exists|fence|flat|floor|floral|forall|forces|frown|gender|gimel|gradient|grave|gt|guarani|harpoons?|hash|hat|hexa|hourglass|hryvnia|hyph|image|in|infinity|integral|inter|interleave|interrobang|join|jupiter|kip|laplace|lari|lat|lira|lozenge|lrm|lt|macron|maltese|manat|mapsto|mars|mercury|minus|miny|models|multimap|mustache|nabla|naira|natural|neptune|note?|nothing|numero|oo|or|original|parallel|parallelogram|paren|partial|pataca|penta|percent|permille|permyriad|perp|peso|pilcrow|planck|plus|pound|power|prec|prime|product|prop|qed|quest|quote|ratio|rect|refmark|rest|riel|rlm|ruble|rupee|saturn|section|semi|sha|sharp|shell|shekel|slash|smash|smile|smt|som|space|square|star|subset|succ|suit|sum|sun|supset|tack|taka|taman|tenge|therefore|tilde|times|tiny|togrog|top|trademark|triangle|union|uranus|venus|without|wj|won|wreath|xor|yen|yuan|zwj|zwnj|zws){{break}}
+      scope: support.constant.sym.typst


### PR DESCRIPTION
Depends on #5 (only because it modifies example book).

Updates the Typst's sublime syntax. Its last update in this repository was 3 years ago, while [the source code](https://github.com/hyrious/typst-syntax-highlight/blob/main/Typst.sublime-syntax) is updated regularly.

The main change that I noticed first was the highlighting of the code inside the inline code blocks (see below).

<img width="1153" height="541" alt="image" src="https://github.com/user-attachments/assets/b13f2887-492f-41e5-82c7-e5cc9040fc32" />
